### PR TITLE
Switched to pygments.rb which is faster successor of Albino

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Transmuter is a command line tool to convert Markdown and Textile files into HTML or PDF, or HTML files to PDF.
 
-It uses [Albino](https://github.com/github/albino),
+It uses [pygments.rb](https://github.com/tmm1/pygments.rb),
 [PDFkit](https://github.com/jdpace/PDFKit),
 [Redcarpet](https://github.com/tanoku/redcarpet), and 
 [RedCloth](http://redcloth.org).
@@ -17,7 +17,7 @@ It uses [Albino](https://github.com/github/albino),
     $ gem install transmuter
     ```
 
-2. Transmuter uses [Albino](https://github.com/github/albino), which requires [Pygments](http://pygments.org/). You can install Pygments using the Python [Easy_Install](http://peak.telecommunity.com/DevCenter/EasyInstall) tool. After installing Easy_Install, you can install Pygments as a Python egg:
+2. Transmuter uses [pygments.rb](https://github.com/tmm1/pygments.rb), which requires [Pygments](http://pygments.org/). You can install Pygments using the Python [Easy_Install](http://peak.telecommunity.com/DevCenter/EasyInstall) tool. After installing Easy_Install, you can install Pygments as a Python egg:
 
       ```bash
       $ sudo easy_install pygments

--- a/bin/transmute
+++ b/bin/transmute
@@ -6,9 +6,6 @@ $:.push File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'transmuter'
 
 # Verify requirements
-unless which("pygmentize")
-  abort "Please install pygments, please read the README.md file for more information"
-end
 
 unless which("wkhtmltopdf")
   abort "Please install wkhtmltopdf, please read the README.md file for more information"

--- a/lib/transmuter/format/html.rb
+++ b/lib/transmuter/format/html.rb
@@ -1,4 +1,4 @@
-require 'albino'
+require 'pygments.rb'
 require 'nokogiri'
 
 module Transmuter
@@ -72,7 +72,7 @@ module Transmuter
         def syntax_highlighter
           doc = Nokogiri::HTML(@html)
           doc.search("//pre[@lang]").each do |pre|
-            pre.replace Albino.colorize(pre.text.rstrip, pre[:lang].downcase.to_sym)
+            pre.replace Pygments.highlight(pre.text.rstrip, :lexer => pre[:lang].downcase.to_sym)
           end
           doc.to_s
         end

--- a/spec/transmuter/format/html_spec.rb
+++ b/spec/transmuter/format/html_spec.rb
@@ -95,7 +95,7 @@ module Format
         subject.send :syntax_highlighter
       end
 
-      it "should call Albino.colorize" do
+      it "should call Pygments.highlight" do
         pre = mock
         pre.stubs(:text).returns("some html")
         pre.stubs(:[]).with(:lang).returns(:ruby)
@@ -104,7 +104,7 @@ module Format
         nokogiri_document.stubs(:search).returns([pre])
         Nokogiri.expects(:HTML).with(html_h1).once.returns(nokogiri_document)
 
-        Albino.expects(:colorize).once.returns("")
+        Pygments.expects(:highlight).once.returns("")
         subject.send(:syntax_highlighter)
       end
     end

--- a/transmuter.gemspec
+++ b/transmuter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'pdfkit', '~>0.5.2'
   s.add_dependency 'redcarpet', '~>1.17.2'
   s.add_dependency 'RedCloth', '~>4.2.8'
-  s.add_dependency 'albino', '~>1.3.3'
+  s.add_dependency 'pygments.rb', '~>0.2.4'
   s.add_dependency 'nokogiri', '~>1.5.0'
 
   # Development dependencies


### PR DESCRIPTION
I did this just to make transmuter work because which('pygments') failed for me, and it was easier for me to switch to newer library that to dig into solving path problem. Seems like pygments.rb is official successor of Albino, and they claim that pygments.rb is faster.
