### PR TITLE
Updated pygments version

### DIFF
--- a/lib/transmuter/version.rb
+++ b/lib/transmuter/version.rb
@@ -1,7 +1,7 @@
 module Transmuter
   MAJOR = 0
   MINOR = 1
-  PATCH = 0
+  PATCH = 1
 
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/transmuter.gemspec
+++ b/transmuter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'pdfkit', '~>0.5.2'
   s.add_dependency 'redcarpet', '~>1.17.2'
   s.add_dependency 'RedCloth', '~>4.2.8'
-  s.add_dependency 'pygments.rb', '~>0.2.4'
+  s.add_dependency 'pygments.rb', '~>0.3.4'
   s.add_dependency 'nokogiri', '~>1.5.0'
 
   # Development dependencies


### PR DESCRIPTION
pygments.rb ~>0.2.4 throws [an error](https://github.com/tmm1/pygments.rb/issues/35) for some of us which prevents `transmute` from working. I just bumped it up to the latest version.
